### PR TITLE
Expose touchTracker as a protected variable of pointerEvents.

### DIFF
--- a/events.js
+++ b/events.js
@@ -21,6 +21,11 @@ define([
 		};
 
 	/**
+	 * @protected
+	 */
+	pointerEvents.touchTracker = touch.touchTracker,
+
+	/**
 	 * Enable Pointer events. Register native event handlers. Importing this module automatically register native
 	 * event handlers on window.document, unless you specify a target element.
 	 *

--- a/handlers/touch.js
+++ b/handlers/touch.js
@@ -391,6 +391,12 @@ define([
 	};
 
 	return {
+		
+		/**
+		 * @protected
+		 */
+		touchTracker: TouchTracker,
+
 		/**
 		 * register touch events handlers.
 		 *
@@ -435,5 +441,6 @@ define([
 		releasePointerCapture: function (targetElement, pointerId) {
 			return TouchTracker.releaseCapture(pointerId - 2, targetElement, false);
 		}
+
 	};
 });


### PR DESCRIPTION
This allows implementing the following pattern to drag and drop an item in a list on touch devices:

Items are moved within the list using drag and drop. When an item is “pressed” (pointerdown event) for more than X seconds without moving, it is grabbed, at which point it can be dragged up and down the list by moving the pointer. When it is dropped, the location of the drop defines where the item should be moved within the list. If an item is "pressed" less that X seconds and the user moves the pointer, the item is not grabbed and the list scroll as usual. Example of an application that implements this pattern: weather app on iOS.

To implement this pattern using pointer events, one need to be able to change the default touch action after the initial pointer down event: accessing the touchTracker allows to do this.
